### PR TITLE
Fixes Issue #13: New refresh rate change implementation does not infact change the refresh rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Under Plans, you can configure as many or few plans as you want. A plan includes
   dgpu_enabled:
     Whether you want the dedicated NVIDIA GPU enabled (uses more power, need for graphics/games), `true`, `false`
   screen_hz:
-    The refresh rate of the screen. Can be 60 (numeric) or 120 (numeric) (for supported models) or null for default
+    The refresh rate of the screen. Can be 60 (numeric) or 120 (numeric) (for supported models) or null for default refresh rate of your monitor
 ```
 
 The config.yaml has many examples of plans included by default. Modify at will.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Under Plans, you can configure as many or few plans as you want. A plan includes
   dgpu_enabled:
     Whether you want the dedicated NVIDIA GPU enabled (uses more power, need for graphics/games), `true`, `false`
   screen_hz:
-    The refresh rate of the screen. Can be 60 (numeric) or 120 (numeric) (for supported models) or null for default refresh rate of your monitor
+    The refresh rate of the screen. Can be 60 (numeric) or 120 (numeric) (for supported models) or null for default refresh rate of your screen
 ```
 
 The config.yaml has many examples of plans included by default. Modify at will.


### PR DESCRIPTION
This fixes Issue #13 , in which the screen refresh rate is not changing as expected

- fixes check that checks whether monitor is capable of 120Hz refresh rate, previously always returned FALSE (not sure why this was, think it had to do with all the line breaks in the output, however came up with alternative check)
- imported `re` module required for above check
- Added some clarifying comments
- Checked whether it was a 120Hz monitor prior to attempting to change the refresh rate
- If `screen_hz` in config.yaml is set to null, set to default monitor refresh rate (120Hz for those models)
- Fixed plan code to actually change refresh rate on plan change
- Clarified instructions 