### PR TITLE
Fixes Issue8: Auto switch profiles based on AC/DC

### DIFF
--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -54,13 +54,11 @@ def power_check():
                     if plan['name'] == default_ac_plan:
                         break
                 apply_plan(plan)
-                print("finished applying AC plan: " + default_ac_plan)
             if not ac and current_plan != default_dc_plan:      # If on DC power, and not on the default_dc_plan, switch to that plan
                 for plan in config['plans']:
                     if plan['name'] == default_dc_plan:
                         break
                 apply_plan(plan)
-                print("finished applying DC plan: " + default_dc_plan)
             time.sleep(10)
     else:
         return

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -68,14 +68,14 @@ def power_check():
 def activate_powerswitching():
     global auto_power_switch
     auto_power_switch = True
-    time.sleep(5)
+    time.sleep(5)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
     notify("Auto power switching has been ENABLED")
 
 
 def deactivate_powerswitching():
     global auto_power_switch
     auto_power_switch = False
-    time.sleep(5)
+    time.sleep(5)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
     notify("Auto power switching has been DISABLED")
 
 

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -50,9 +50,17 @@ def power_check():
         while True:
             ac = psutil.sensors_battery().power_plugged     # Get the current AC power status
             if ac and current_plan != default_ac_plan:      # If on AC power, and not on the default_ac_plan, switch to that plan
-                apply_plan(default_ac_plan)
+                for plan in config['plans']:
+                    if plan['name'] == default_ac_plan:
+                        break
+                apply_plan(plan)
+                print("finished applying AC plan: " + default_ac_plan)
             if not ac and current_plan != default_dc_plan:      # If on DC power, and not on the default_dc_plan, switch to that plan
-                apply_plan(default_dc_plan)
+                for plan in config['plans']:
+                    if plan['name'] == default_dc_plan:
+                        break
+                apply_plan(plan)
+                print("finished applying DC plan: " + default_dc_plan)
             time.sleep(10)
     else:
         return

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -68,11 +68,15 @@ def power_check():
 def activate_powerswitching():
     global auto_power_switch
     auto_power_switch = True
+    time.sleep(5)
+    notify("Auto power switching has been ENABLED")
 
 
 def deactivate_powerswitching():
     global auto_power_switch
     auto_power_switch = False
+    time.sleep(5)
+    notify("Auto power switching has been DISABLED")
 
 
 def notify(message):

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -68,14 +68,14 @@ def power_check():
 def activate_powerswitching():
     global auto_power_switch
     auto_power_switch = True
-    time.sleep(5)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
+    time.sleep(10)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
     notify("Auto power switching has been ENABLED")
 
 
 def deactivate_powerswitching():
     global auto_power_switch
     auto_power_switch = False
-    time.sleep(5)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
+    time.sleep(10)   # Plan change notifies first, so this needs to be on a delay to prevent simultaneous notifications
     notify("Auto power switching has been DISABLED")
 
 

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -45,11 +45,17 @@ def create_icon():
 
 
 def power_check():
-    global ac
-    while True:
-        ac = psutil.sensors_battery().power_plugged
-        time.sleep(10)
-
+    global ac, current_plan, default_ac_plan, default_dc_plan
+    if default_ac_plan is not None and default_dc_plan is not None:     # Don't run if default power plans are not set (null)
+        while True:
+            ac = psutil.sensors_battery().power_plugged     # Get the current AC power status
+            if ac and current_plan != default_ac_plan:      # If on AC power, and not on the default_ac_plan, switch to that plan
+                apply_plan(default_ac_plan)
+            if not ac and current_plan != default_dc_plan:      # If on DC power, and not on the default_dc_plan, switch to that plan
+                apply_plan(default_dc_plan)
+            time.sleep(10)
+    else:
+        return
 
 def notify(message):
     Thread(target=do_notify, args=(message,), daemon=True).start()
@@ -242,9 +248,11 @@ def load_config():  # Small function to load the config and return it after pars
 
 if __name__ == "__main__":
     if is_admin() or os.environ['PYCHARM']:  # If running as admin or in debug mode, launch program
-        current_plan = "DEFAULT"
         config = load_config()  # Make the config available to the whole script
-        ac = None  # Defining a variable for ac power
+        current_plan = config['default_starting_plan']
+        default_ac_plan = config['default_ac_plan']
+        default_dc_plan = config['default_dc_plan']
+        ac = psutil.sensors_battery().power_plugged  # Set AC/battery status on start
         Thread(target=power_check, daemon=True).start()  # A process in the background will check for AC
         resources.extract(config['temp_dir'])
         icon_app = pystray.Icon(config['app_name'])  # Initialize the icon app and set its name

--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -92,7 +92,7 @@ def get_current():
         "Plan: " + current_plan + "\n" +
         "Boost: " + (["Off", "On"][get_boost()]) + "     dGPU: " + (["Off", "On"][get_dgpu()]) + "\n" +
         "Refresh Rate: " + (["60Hz", "120Hz"][get_screen()]) + "\n" +
-        "Power: " + (["Battery", "AC"][bool(ac)]) + "\n"
+        "Power: " + (["Battery", "AC"][bool(ac)]) + "     Auto Switching: " + (["Off", "On"][auto_power_switch]) + "\n"
     )  # Let's print the current values
 
 
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         default_ac_plan = config['default_ac_plan']
         default_dc_plan = config['default_dc_plan']
         ac = psutil.sensors_battery().power_plugged  # Set AC/battery status on start
-        if default_ac_plan is not None and default_dc_plan is not None:  # Only enable auto_power_plan on boot if default power plans are enabled (not set to null)
+        if default_ac_plan is not None and default_dc_plan is not None:  # Only enable auto_power_switch on boot if default power plans are enabled (not set to null)
             auto_power_switch = True
         else:
             auto_power_switch = False

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Edit the config.yml with text editor as needed (see configuring below)
 To make it run on boot, you will need to follow these instructions since it requires administrator privileges: https://www.sevenforums.com/tutorials/11949-elevated-program-shortcut-without-uac-prompt-create.html
 
 ### Configuring
-All done in config.yaml within the root folder of the program. The program must be restarted for any changes to the config.yaml to take effect. 
+All done in config.yaml within the root folder of the program. The program must be restarted for any changes to the config.yaml to take effect.
 
 `app_name:` can be customized, this is what the hover text displays over the icon and the windows notification title
 
 `default_starting_plan` set plan name you want on boot or on restart of the program
 
-`default_ac_plan` This plan name will automatically enable when AC adapter plugged in (set both default_ac_plan and default_dc_plan) to `null` to disable this feature
+`default_ac_plan` This plan name will automatically enable when AC adapter plugged in (set both default_ac_plan and default_dc_plan to `null` to disable this feature)
 
-`default_dc_plan` This plan name will automatically enable when on battery power (set both default_ac_plan and default_dc_plan) to `null` to disable this feature
+`default_dc_plan` This plan name will automatically enable when on battery power (set both default_ac_plan and default_dc_plan to `null` to disable this feature)
 
 ##### Power Plans:
 Under Plans, you can configure as many or few plans as you want. A plan includes:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Edit the config.yml with text editor as needed (see configuring below)
 To make it run on boot, you will need to follow these instructions since it requires administrator privileges: https://www.sevenforums.com/tutorials/11949-elevated-program-shortcut-without-uac-prompt-create.html
 
 ### Configuring
+All done in config.yaml within the root folder of the program. The program must be restarted for any changes to the config.yaml to take effect. 
+
+`app_name:` can be customized, this is what the hover text displays over the icon and the windows notification title
+
+`default_starting_plan` set plan name you want on boot or on restart of the program
+
+`default_ac_plan` This plan name will automatically enable when AC adapter plugged in (set both default_ac_plan and default_dc_plan) to `null` to disable this feature
+
+`default_dc_plan` This plan name will automatically enable when on battery power (set both default_ac_plan and default_dc_plan) to `null` to disable this feature
+
+##### Power Plans:
 Under Plans, you can configure as many or few plans as you want. A plan includes:
 ```
 - name:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ All done in config.yaml within the root folder of the program. The program must 
 
 `default_dc_plan` This plan name will automatically enable when on battery power (set both default_ac_plan and default_dc_plan to `null` to disable this feature)
 
+##### Notes on using Auto Power Switching:
+- Only available if `default_ac_plan` and `default_dc_plan` are set in config (set to `null` to disable)
+- Manually changing your plan thru the icon menu will DISABLE auto power switching.
+- To re-enable, click the "Re-Enable Auto Power Switching" option in the icon menu.
+
 ##### Power Plans:
 Under Plans, you can configure as many or few plans as you want. A plan includes:
 ```

--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,9 @@ app_name: "G14 Control"  # Name of the app, you can customize that as you wish!
 notification_time: 3  # How long notifications will stay on the screen
 check_power_every: 10  # Seconds in between checks to get the battery/ac status
 temp_dir: 'C:\temp\' # MUST END with "\"!!
+default_starting_plan: "Windows"
+default_ac_plan: "Performance"
+default_dc_plan: "Silent (low-speed fan)"
 plans:
   - name: Silent (fanless)
     plan: silent


### PR DESCRIPTION
This enhancement allows user to set auto power profile switching between ac/dc power, fixes Issue #8 

- can be enabled or disabled in config
- can set a default startup plan (useful if not using autoswitching)
- autoswitching is disabled when user manually selects a plan
- autoswitching can manually be re-enabled from icon menu
- Info notification now indicates whether autoswitching is on or now
- A delayed notification appears to let you know when autoswitching is enabled or disabled
- Instructions have been updated accordingly