### PR TITLE
Fixes Issue#25: Change boost state based on running application(s)?

### DIFF
--- a/G14Control.pyw
+++ b/G14Control.pyw
@@ -51,28 +51,28 @@ def power_check():
         time.sleep(10)
 
 
-def gaming_check():
+def gaming_check():     # Checks if user specified games/programs are running, and switches to user defined plan, then switches back once closed
     global default_gaming_plan, default_gaming_plan_games
-    previous_plan = None
-    while True:
-        processes = set(p.name() for p in psutil.process_iter())
-        targets = set(default_gaming_plan_games)
-        if processes & targets:
+    previous_plan = None    # Define the previous plan to switch back to
+    while True: # Continuously check every 10 seconds
+        processes = set(p.name() for p in psutil.process_iter())    # List of windows processes
+        targets = set(default_gaming_plan_games)    # List of user defined processes
+        if processes & targets:     # Compare 2 lists, if ANY overlap, set game_running to true
             game_running = True
         else:
             game_running = False
-        if game_running and current_plan != default_gaming_plan:
+        if game_running and current_plan != default_gaming_plan:    # If game is running and not on the desired gaming plan, switch to that plan
             previous_plan = current_plan
             for plan in config['plans']:
                 if plan['name'] == default_gaming_plan:
                     break
             apply_plan(plan)
-        if not game_running and previous_plan is not None and previous_plan != current_plan:
+        if not game_running and previous_plan is not None and previous_plan != current_plan:    # If game is no longer running, and not on previous plan already (if set), then switch back to previous plan
             for plan in config['plans']:
                 if plan['name'] == previous_plan:
                     break
             apply_plan(plan)
-        time.sleep(10)
+        time.sleep(10)      # Check for programs every 10 sec
 
 
 def notify(message):
@@ -283,7 +283,7 @@ if __name__ == "__main__":
         Thread(target=power_check, daemon=True).start()  # A process in the background will check for AC
         default_gaming_plan_games = config['default_gaming_plan_games']
         default_gaming_plan = config['default_gaming_plan']
-        if config['default_gaming_plan'] is not None and config['default_gaming_plan_games'] is not None:
+        if config['default_gaming_plan'] is not None and config['default_gaming_plan_games'] is not None:   # Check if the gaming auto switch is enabled (both user variables are not null), then start a thread to continuously monitor processes in background.
             Thread(target=gaming_check, daemon=True).start()
         resources.extract(config['temp_dir'])
         icon_app = pystray.Icon(config['app_name'])  # Initialize the icon app and set its name

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Edit the config.yml with text editor as needed (see configuring below)
 To make it run on boot, you will need to follow these instructions since it requires administrator privileges: https://www.sevenforums.com/tutorials/11949-elevated-program-shortcut-without-uac-prompt-create.html
 
 ### Configuring
+All done in config.yaml within the root folder of the program. The program must be restarted for any changes to the config.yaml to take effect.
+
+`app_name:` can be customized, this is what the hover text displays over the icon and the windows notification title
+
+`default_starting_plan` set plan name you want on boot or on restart of the program
+
+`default_ac_plan` This plan name will automatically enable when AC adapter plugged in (set both default_ac_plan and default_dc_plan to `null` to disable this feature)
+
+`default_dc_plan` This plan name will automatically enable when on battery power (set both default_ac_plan and default_dc_plan to `null` to disable this feature)
+
+`default_gaming_plan` Enable this if you want the program to auto-switch plans based on games (or any program really) running. It will automatically switch to the plan specified here when the program is launched, and automatically switch back to the previous plan once it has closed. Set to `null` to disable.
+- WARNING: this may be more resource intensive as it polls running processes on your computer every 10 seconds. However I noticed little difference, and almost no score change on Heaven Benchmark (FPS +/- 2).
+
+`default_gaming_plan_games` This will be a list of exe's that you want to detect. Please check the exact name of the exe. For example, Steam is SteamService.exe. Example list: ["7zFM.exe", "notepad++.exe", "SteamService.exe"]
+
+
+##### Configure plans
 Under Plans, you can configure as many or few plans as you want. A plan includes:
 ```
 - name:

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,8 @@
 app_name: "G14 Control"  # Name of the app, you can customize that as you wish!
 notification_time: 3  # How long notifications will stay on the screen
 check_power_every: 10  # Seconds in between checks to get the battery/ac status
+default_gaming_plan: null   # Example: "Turbo"
+default_gaming_plan_games: null   # Example list: ["7zFM.exe", "notepad++.exe"]
 temp_dir: 'C:\temp\' # MUST END with "\"!!
 debug: false # true/false Don't change unless you know what you are doing!!!
 plans:


### PR DESCRIPTION
Enhancement for Issue #25 
Created Auto Game Switching mode, which automatically changes the plan based on whether user defined programs are running or not, then changes it back to previous once that program(s) closes.

Updated config variables for user, and readme with instructions.
